### PR TITLE
Actualizar OpenAPI para funcionar con Spring Boot 3, arreglar endpoint de busqueda

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,13 +26,13 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-hateoas")
     implementation("org.springframework.boot:spring-boot-starter-data-rest")
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.springframework.boot:spring-boot-starter-web-services")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.2") //
-    implementation("org.springdoc:springdoc-openapi-ui:1.6.14")
+    implementation("org.springdoc:springdoc-openapi-starter-common:2.2.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
     implementation("org.springframework.boot:spring-boot-devtools")
 
     // testing

--- a/src/main/kotlin/org/uqbar/tareas/bootstrap/TareasBootstrap.kt
+++ b/src/main/kotlin/org/uqbar/tareas/bootstrap/TareasBootstrap.kt
@@ -1,7 +1,6 @@
 package org.uqbar.tareas.bootstrap
 
 import org.springframework.beans.factory.InitializingBean
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.uqbar.tareas.domain.Usuario
 import org.uqbar.tareas.repository.TareasRepository
@@ -9,16 +8,13 @@ import org.uqbar.tareas.repository.UsuariosRepository
 import java.time.LocalDate
 
 @Service
-class TareasBootstrap : InitializingBean {
+class TareasBootstrap(
+    val tareasRepository: TareasRepository,
+    val usuariosRepository: UsuariosRepository
+) : InitializingBean {
 
-    @Autowired
-    lateinit var tareasRepository: TareasRepository
-
-    @Autowired
-    lateinit var usuariosRepository: UsuariosRepository
-
-    lateinit var juan: Usuario
-    lateinit var rodrigo: Usuario
+    private lateinit var juan: Usuario
+    private lateinit var rodrigo: Usuario
 
     fun crearTareas() {
         val thisYear = LocalDate.now().year

--- a/src/main/kotlin/org/uqbar/tareas/controller/TareasController.kt
+++ b/src/main/kotlin/org/uqbar/tareas/controller/TareasController.kt
@@ -22,7 +22,17 @@ class TareasController {
    fun tareaPorId(@PathVariable id: Int) = tareasService.tareaPorId(id)
 
    @GetMapping("/tareas/search")
-   @Operation(summary = "Devuelve todas las tareas cuya descripción contiene la descripción que pasamos como parámetro")
+   @Operation(
+      deprecated = true,
+      summary = "Devuelve todas las tareas cuya descripción contiene la descripción que pasamos como parámetro",
+      description = "No utilizar este endpoint, ya que puede no funcionar correctamente. Utilizar el equivalente de tipo POST en cambio"
+   )
+   fun oldBuscar(@RequestBody tareaBusqueda: Tarea) = tareasService.buscar(tareaBusqueda)
+
+   @PostMapping("/tareas/search")
+   @Operation(
+      summary = "Devuelve todas las tareas cuya descripción contiene la descripción que pasamos como parámetro",
+   )
    fun buscar(@RequestBody tareaBusqueda: Tarea) = tareasService.buscar(tareaBusqueda)
 
    @PutMapping("/tareas/{id}")

--- a/src/main/kotlin/org/uqbar/tareas/controller/TareasController.kt
+++ b/src/main/kotlin/org/uqbar/tareas/controller/TareasController.kt
@@ -23,17 +23,9 @@ class TareasController {
 
    @GetMapping("/tareas/search")
    @Operation(
-      deprecated = true,
-      summary = "Devuelve todas las tareas cuya descripción contiene la descripción que pasamos como parámetro",
-      description = "No utilizar este endpoint, ya que puede no funcionar correctamente. Utilizar el equivalente de tipo POST en cambio"
+      summary = "Devuelve todas las tareas cuya descripción contiene los valores pasados por parametro"
    )
-   fun oldBuscar(@RequestBody tareaBusqueda: Tarea) = tareasService.buscar(tareaBusqueda)
-
-   @PostMapping("/tareas/search")
-   @Operation(
-      summary = "Devuelve todas las tareas cuya descripción contiene la descripción que pasamos como parámetro",
-   )
-   fun buscar(@RequestBody tareaBusqueda: Tarea) = tareasService.buscar(tareaBusqueda)
+   fun buscar(@RequestParam(name = "descripcion") descripcionTarea: String) = tareasService.buscar(Tarea().apply{descripcion = descripcionTarea})
 
    @PutMapping("/tareas/{id}")
    @Operation(summary = "Permite actualizar la información de una tarea")

--- a/src/main/kotlin/org/uqbar/tareas/controller/TareasController.kt
+++ b/src/main/kotlin/org/uqbar/tareas/controller/TareasController.kt
@@ -1,17 +1,13 @@
 package org.uqbar.tareas.controller
 
 import io.swagger.v3.oas.annotations.Operation
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.*
 import org.uqbar.tareas.domain.Tarea
 import org.uqbar.tareas.service.TareasService
 
 @RestController
 @CrossOrigin("*")
-class TareasController {
-
-   @Autowired
-   lateinit var tareasService: TareasService
+class TareasController(val tareasService: TareasService) {
 
    @GetMapping("/tareas")
    @Operation(summary = "Devuelve todas las tareas")

--- a/src/main/kotlin/org/uqbar/tareas/controller/UsuariosController.kt
+++ b/src/main/kotlin/org/uqbar/tareas/controller/UsuariosController.kt
@@ -1,7 +1,6 @@
 package org.uqbar.tareas.controller
 
 import io.swagger.v3.oas.annotations.Operation
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
@@ -9,10 +8,9 @@ import org.uqbar.tareas.service.UsuariosService
 
 @RestController
 @CrossOrigin("*")
-class UsuariosController {
-
-    @Autowired
-    lateinit var usuariosService: UsuariosService
+class UsuariosController(
+   val usuariosService: UsuariosService
+) {
 
     @GetMapping("/usuarios")
     @Operation(summary = "Devuelve todos los usuarios")

--- a/src/main/kotlin/org/uqbar/tareas/domain/Tarea.kt
+++ b/src/main/kotlin/org/uqbar/tareas/domain/Tarea.kt
@@ -9,8 +9,8 @@ import java.time.format.DateTimeFormatter
 class Tarea : Entity() {
     companion object {
         const val TAREA_COMPLETA = 100
-        const val DATE_PATTERN = "dd/MM/yyyy"
-        val formatter = DateTimeFormatter.ofPattern(DATE_PATTERN)
+        private const val DATE_PATTERN = "dd/MM/yyyy"
+        private val formatter = DateTimeFormatter.ofPattern(DATE_PATTERN)
     }
 
     var descripcion = ""
@@ -26,9 +26,6 @@ class Tarea : Entity() {
     fun validar() {
         if (descripcion.isEmpty()) {
             throw BusinessException("Debe ingresar descripcion")
-        }
-        if (fecha === null) {
-            throw BusinessException("Debe ingresar fecha")
         }
     }
 

--- a/src/main/kotlin/org/uqbar/tareas/domain/Tarea.kt
+++ b/src/main/kotlin/org/uqbar/tareas/domain/Tarea.kt
@@ -42,10 +42,12 @@ class Tarea : Entity() {
     }
 
     @JsonProperty("fecha")
-    fun getFechaAsString() = formatter.format(this.fecha)
+    fun getFechaAsString(): String = formatter.format(this.fecha)
 
     @JsonProperty("fecha")
-    fun asignarFecha(fecha: String) {
+    fun asignarFecha(fecha: String?) {
+        if (fecha === null)
+            throw BusinessException("Debe ingresar una fecha")
         this.fecha = LocalDate.parse(fecha, formatter)
     }
 

--- a/src/main/kotlin/org/uqbar/tareas/errors/Errors.kt
+++ b/src/main/kotlin/org/uqbar/tareas/errors/Errors.kt
@@ -5,9 +5,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import java.lang.RuntimeException
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)
-class BusinessException(msg: String) : RuntimeException(msg) {
-}
+class BusinessException(msg: String) : RuntimeException(msg)
 
 @ResponseStatus(HttpStatus.NOT_FOUND)
-class NotFoundException(msg: String) : RuntimeException(msg) {
-}
+class NotFoundException(msg: String) : RuntimeException(msg)

--- a/src/main/kotlin/org/uqbar/tareas/repository/TareasRepository.kt
+++ b/src/main/kotlin/org/uqbar/tareas/repository/TareasRepository.kt
@@ -11,7 +11,7 @@ class TareasRepository {
     val tareas = mutableListOf<Tarea>()
 
     companion object {
-        var ultimoId = 1
+        private var ultimoId = 1
     }
 
     fun allInstances(): List<Tarea> {

--- a/src/main/kotlin/org/uqbar/tareas/repository/UsuariosRepository.kt
+++ b/src/main/kotlin/org/uqbar/tareas/repository/UsuariosRepository.kt
@@ -8,7 +8,7 @@ class UsuariosRepository {
     val usuarios = mutableListOf<Usuario>()
 
     companion object {
-        var ultimoId = 1
+        private var ultimoId = 1
     }
 
     fun allInstances() = usuarios.sortedBy { it.nombre }

--- a/src/main/kotlin/org/uqbar/tareas/service/TareasService.kt
+++ b/src/main/kotlin/org/uqbar/tareas/service/TareasService.kt
@@ -21,7 +21,10 @@ class TareasService(
    fun buscar(tareaBusqueda: Tarea) = tareasRepository.search(tareaBusqueda)
 
    fun actualizar(id: Int, tareaActualizada: Tarea): Tarea {
-      if (tareaActualizada.id !== null && tareaActualizada.id != id) {
+      if (tareaActualizada.id == null) {
+         throw BusinessException("Debe proveerse el ID de la tarea a actualizar")
+      }
+      if (tareaActualizada.id!! != id) {
          throw BusinessException("Id en URL distinto del id que viene en el body")
       }
       val tarea = tareaPorId(id)

--- a/src/main/kotlin/org/uqbar/tareas/service/TareasService.kt
+++ b/src/main/kotlin/org/uqbar/tareas/service/TareasService.kt
@@ -1,6 +1,5 @@
 package org.uqbar.tareas.service
 
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.uqbar.tareas.domain.Tarea
 import org.uqbar.tareas.errors.BusinessException
@@ -9,13 +8,10 @@ import org.uqbar.tareas.repository.TareasRepository
 import org.uqbar.tareas.repository.UsuariosRepository
 
 @Service
-class TareasService {
-
-   @Autowired
-   lateinit var tareasRepository: TareasRepository
-
-   @Autowired
-   lateinit var usuariosRepository: UsuariosRepository
+class TareasService(
+   val tareasRepository: TareasRepository,
+   val usuariosRepository: UsuariosRepository
+) {
 
    fun tareas() = tareasRepository.allInstances()
 

--- a/src/main/kotlin/org/uqbar/tareas/service/UsuariosService.kt
+++ b/src/main/kotlin/org/uqbar/tareas/service/UsuariosService.kt
@@ -1,14 +1,12 @@
 package org.uqbar.tareas.service
 
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.uqbar.tareas.repository.UsuariosRepository
 
 @Service
-class UsuariosService {
-
-   @Autowired
-   lateinit var usuariosRepository: UsuariosRepository
+class UsuariosService(
+   val usuariosRepository: UsuariosRepository
+) {
 
    fun allInstances() = usuariosRepository.allInstances()
 

--- a/src/test/kotlin/org/uqbar/tareas/controller/TareasControllerTest.kt
+++ b/src/test/kotlin/org/uqbar/tareas/controller/TareasControllerTest.kt
@@ -63,12 +63,9 @@ class TareasControllerTest(@Autowired val mockMvc: MockMvc) {
     @Test
     fun `se pueden pedir las tareas que contengan cierta descripcion`() {
         val tareaBusqueda = buildTarea()
-        println(ObjectMapper().writeValueAsString(tareaBusqueda))
         mockMvc
             .perform(
-                MockMvcRequestBuilders.get("/tareas/search")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(ObjectMapper().writeValueAsString(tareaBusqueda))
+                MockMvcRequestBuilders.get("/tareas/search?descripcion=${tareaBusqueda.descripcion}")
             )
             .andExpect(status().isOk)
             .andExpect(content().contentType("application/json"))
@@ -84,9 +81,7 @@ class TareasControllerTest(@Autowired val mockMvc: MockMvc) {
         mockMvc
             .perform(
                 MockMvcRequestBuilders
-                    .get("/tareas/search")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(ObjectMapper().writeValueAsString(tareaBusqueda))
+                    .get("/tareas/search?descripcion=${tareaBusqueda.descripcion}")
             )
             .andExpect(status().isOk)
             .andExpect(content().contentType("application/json"))

--- a/src/test/kotlin/org/uqbar/tareas/controller/TareasControllerTest.kt
+++ b/src/test/kotlin/org/uqbar/tareas/controller/TareasControllerTest.kt
@@ -48,7 +48,7 @@ class TareasControllerTest(@Autowired val mockMvc: MockMvc) {
         })
     }
 
-    // region tareas
+    // region GET /tareas
     @Test
     fun `se pueden obtener todas las tareas`() {
         mockMvc
@@ -57,9 +57,9 @@ class TareasControllerTest(@Autowired val mockMvc: MockMvc) {
             .andExpect(content().contentType("application/json"))
             .andExpect(jsonPath("$.length()").value(2))
     }
-    // end region
+    // endregion
 
-    // region tareas/search
+    // region GET /tareas/search
     @Test
     fun `se pueden pedir las tareas que contengan cierta descripcion`() {
         val tareaBusqueda = buildTarea()
@@ -87,9 +87,9 @@ class TareasControllerTest(@Autowired val mockMvc: MockMvc) {
             .andExpect(content().contentType("application/json"))
             .andExpect(jsonPath("$.length()").value(0))
     }
-    // end region
+    // endregion
 
-    // region tareas/{id}
+    // region GET /tareas/{id}
     @Test
     fun `se puede obtener una tarea por su id`() {
         mockMvc
@@ -106,9 +106,9 @@ class TareasControllerTest(@Autowired val mockMvc: MockMvc) {
             .perform(MockMvcRequestBuilders.get("/tareas/20000"))
             .andExpect(status().isNotFound)
     }
-    // end region
+    // endregion
 
-    // region actualizar tarea
+    // region [actualizar] PUT /tareas/{id}
     @Test
     fun `actualizar una tarea a un valor valido actualiza correctamente`() {
         val tareaValida = buildTarea().apply {
@@ -222,9 +222,9 @@ class TareasControllerTest(@Autowired val mockMvc: MockMvc) {
 
         assertEquals(errorMessage, "Id en URL distinto del id que viene en el body")
     }
-    // end region
+    // endregion
 
-    // region crear tarea
+    // region [crear] POST /tareas
     @Test
     fun `crear una tarea a un valor valido actualiza correctamente`() {
         val descripcionNuevaTarea = "Implementar un servicio REST para crear una tarea"
@@ -311,9 +311,9 @@ class TareasControllerTest(@Autowired val mockMvc: MockMvc) {
 
         assertEquals(errorMessage, "No se encontró el usuario <Mengueche>")
     }
-    // end region
+    // endregion
 
-    // region delete tarea
+    // region DELETE /tarea/{descripcion}
     @Test
     fun `se puede eliminar una tarea existente en forma exitosa`() {
         val descripcion = "Resolver consulta de usuarios sin tareas"
@@ -337,7 +337,7 @@ class TareasControllerTest(@Autowired val mockMvc: MockMvc) {
             .andExpect { status().isOk }
             .andExpect(jsonPath("$.length()").value(0))
     }
-    // end region
+    // endregion
 
     fun buildTarea(): Tarea {
         return Tarea().apply {


### PR DESCRIPTION
* Springdoc-openapi se actualiza de 1.6.14 -> 2.2.0 para dar soporte a Spring Boot 3. Parte de la actualización mayor es un cambio en el nombre de dependencias.
* Se elimino una dependenica duplicada de jackson-module-kotlin, y se actualizó jackson-datatype-jsr310 a 2.15.2 como usa la versión de SpringBoot en el proyecto.